### PR TITLE
Performance improvements

### DIFF
--- a/lib/badwords.js
+++ b/lib/badwords.js
@@ -91,7 +91,6 @@ class Filter {
         .join('|'),
       'gi');
   }
-
 }
 
 module.exports = Filter;

--- a/lib/badwords.js
+++ b/lib/badwords.js
@@ -23,6 +23,8 @@ class Filter {
       regex: options.regex || /[^a-zA-Z0-9|\$|\@]|\^/g,
       replaceRegex: options.replaceRegex || /\w/g
     })
+
+    this._setBadWordsRegExp();
   }
 
   /**
@@ -30,12 +32,7 @@ class Filter {
    * @param {string} string - String to evaluate for profanity.
    */
   isProfane(string) {
-    return this.list
-      .filter((word) => {
-        const wordExp = new RegExp(`\\b${word.replace(/(\W)/g, '\\$1')}\\b`, 'gi');
-        return !this.exclude.includes(word.toLowerCase()) && wordExp.test(string);
-      })
-      .length > 0 || false;
+    return this.allBadWordsRegex.test(string);
   }
 
   /**
@@ -66,6 +63,7 @@ class Filter {
     let words = Array.from(arguments);
 
     this.list.push(...words);
+    this._setBadWordsRegExp();
 
     words
       .map(word => word.toLowerCase())
@@ -82,7 +80,18 @@ class Filter {
    */
   removeWords() {
     this.exclude.push(...Array.from(arguments).map(word => word.toLowerCase()));
+    this._setBadWordsRegExp();
   }
+
+  _setBadWordsRegExp() {
+    this.allBadWordsRegex = new RegExp(
+      this.list
+        .filter((word) => !this.exclude.includes(word.toLowerCase()))
+        .map((word) => `\\b${word.replace(/(\W)/g, '\\$1')}\\b`)
+        .join('|'),
+      'gi');
+  }
+
 }
 
 module.exports = Filter;


### PR DESCRIPTION
- Don't create regexp in a loop. The previous code would create a the same regexps for every word in the test string
- Create a regexp from entire string. The javascript runtime probably compiles this into a DFA that runs in linear time over the length of the word (not the length of the RegExp)
- Create the regexp when updating the words list instead of every word